### PR TITLE
exa2

### DIFF
--- a/exa/goddard-exa.jl
+++ b/exa/goddard-exa.jl
@@ -47,7 +47,7 @@ i_print_level = 0
 m_print_level = MadNLP.WARN
 sol = solve(ocp; grid_size=N, print_level=0)
 
-N = 100 
+N = 1000
 print_level = 0
 n = 3
 m = 1

--- a/exa2/Manifest.toml
+++ b/exa2/Manifest.toml
@@ -2,26 +2,7 @@
 
 julia_version = "1.10.4"
 manifest_format = "2.0"
-project_hash = "af18ef0387102762ee53dfedd9d0fa06b0d04ee8"
-
-[[deps.ADNLPModels]]
-deps = ["ADTypes", "ForwardDiff", "LinearAlgebra", "NLPModels", "Requires", "ReverseDiff", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings"]
-git-tree-sha1 = "e8858cf208cb3243b8cc93c4e8f8c9c6a26c0d34"
-uuid = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
-version = "0.8.5"
-
-[[deps.ADTypes]]
-git-tree-sha1 = "5908d630c495e3249cab29c5d5ea0b8de5e6e1fe"
-uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
-version = "1.7.0"
-
-    [deps.ADTypes.extensions]
-    ADTypesChainRulesCoreExt = "ChainRulesCore"
-    ADTypesEnzymeCoreExt = "EnzymeCore"
-
-    [deps.ADTypes.weakdeps]
-    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-    EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+project_hash = "313146870eb49d608bbba2a6e544eeec61dfdee4"
 
 [[deps.AMD]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse_jll"]
@@ -101,47 +82,6 @@ git-tree-sha1 = "389ad5c84de1ae7cf0e28e381131c98ea87d54fc"
 uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 version = "0.5.0"
 
-[[deps.CTBase]]
-deps = ["DataStructures", "DifferentiationInterface", "DocStringExtensions", "ForwardDiff", "Interpolations", "LinearAlgebra", "MLStyle", "MacroTools", "Parameters", "PrettyTables", "Printf", "Reexport", "ReplMaker", "Unicode"]
-git-tree-sha1 = "14e27465259f1b2dd1cebee57b11c0bcf09f0e04"
-uuid = "54762871-cc72-4466-b8e8-f6c8b58076cd"
-version = "0.11.3"
-
-    [deps.CTBase.extensions]
-    CTBasePlots = "Plots"
-
-    [deps.CTBase.weakdeps]
-    Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-
-[[deps.CTDirect]]
-deps = ["ADNLPModels", "CTBase", "CommonSolve", "DocStringExtensions", "HSL", "LinearAlgebra", "NLPModels"]
-git-tree-sha1 = "5f31dc21486136da6e10d3c23bc6cdf873dfdc79"
-uuid = "790bbbee-bee9-49ee-8912-a9de031322d5"
-version = "0.10.0"
-
-    [deps.CTDirect.extensions]
-    CTDirectExt = ["JLD2", "JSON3"]
-    CTSolveExt = ["NLPModelsIpopt"]
-
-    [deps.CTDirect.weakdeps]
-    JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-    JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-    NLPModelsIpopt = "f4238b75-b362-5c4c-b852-0801c9a21d71"
-
-[[deps.CTFlows]]
-deps = ["CTBase", "DocStringExtensions", "MLStyle"]
-git-tree-sha1 = "573f109d573fcd3cf0ebcb8ad4054be3d97e0815"
-uuid = "1c39547c-7794-42f7-af83-d98194f657c2"
-version = "0.4.5"
-
-    [deps.CTFlows.extensions]
-    CTFlowsODE = "OrdinaryDiffEq"
-    CTFlowsPlots = "Plots"
-
-    [deps.CTFlows.weakdeps]
-    OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
-    Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-
 [[deps.CUDA]]
 deps = ["AbstractFFTs", "Adapt", "BFloat16s", "CEnum", "CUDA_Driver_jll", "CUDA_Runtime_Discovery", "CUDA_Runtime_jll", "Crayons", "DataFrames", "ExprTools", "GPUArrays", "GPUCompiler", "KernelAbstractions", "LLVM", "LLVMLoopInfo", "LazyArtifacts", "Libdl", "LinearAlgebra", "Logging", "NVTX", "Preferences", "PrettyTables", "Printf", "Random", "Random123", "RandomNumbers", "Reexport", "Requires", "SparseArrays", "StaticArrays", "Statistics"]
 git-tree-sha1 = "fdd9dfb67dfefd548f51000cc400bb51003de247"
@@ -176,6 +116,24 @@ git-tree-sha1 = "afea94249b821dc754a8ca6695d3daed851e1f5a"
 uuid = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 version = "0.14.1+0"
 
+[[deps.CUDSS]]
+deps = ["CEnum", "CUDA", "CUDSS_jll", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "11cb7c9c06435cfadcc6d94d34c07501df32ce55"
+uuid = "45b445bb-4962-46a0-9369-b4df9d0f772e"
+version = "0.3.2"
+
+[[deps.CUDSS_jll]]
+deps = ["Artifacts", "CUDA_Runtime_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "TOML"]
+git-tree-sha1 = "b4c1defa52f8806ac674ac72c793e9b5599c6e81"
+uuid = "4889d778-9329-5762-9fec-0578a5d30366"
+version = "0.3.0+0"
+
+[[deps.CUSOLVERRF]]
+deps = ["CUDA", "KLU", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "3475fe1155f79768727a5a00c8d4d6a7a632f556"
+uuid = "a8cc9031-bad2-4722-94f5-40deabb4245c"
+version = "0.2.4"
+
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra"]
 git-tree-sha1 = "71acdbf594aab5bbb2cec89b208c41b4c411e49f"
@@ -209,11 +167,6 @@ deps = ["ColorTypes", "FixedPointNumbers", "Reexport"]
 git-tree-sha1 = "362a287c3aa50601b0bc359053d5c2468f0e7ce0"
 uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
 version = "0.12.11"
-
-[[deps.CommonSolve]]
-git-tree-sha1 = "0eee5eb66b1cf62cd6ad1b460238e60e4b09400c"
-uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
-version = "0.2.4"
 
 [[deps.CommonSubexpressions]]
 deps = ["MacroTools", "Test"]
@@ -279,42 +232,6 @@ git-tree-sha1 = "23163d55f885173722d1e4cf0f6110cdbaf7e272"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
 version = "1.15.1"
 
-[[deps.DifferentiationInterface]]
-deps = ["ADTypes", "Compat", "DocStringExtensions", "FillArrays", "LinearAlgebra", "PackageExtensionCompat", "SparseArrays", "SparseMatrixColorings"]
-git-tree-sha1 = "6bd550abccb7aa156141e10d5367c580af9128af"
-uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
-version = "0.5.11"
-
-    [deps.DifferentiationInterface.extensions]
-    DifferentiationInterfaceChainRulesCoreExt = "ChainRulesCore"
-    DifferentiationInterfaceDiffractorExt = "Diffractor"
-    DifferentiationInterfaceEnzymeExt = "Enzyme"
-    DifferentiationInterfaceFastDifferentiationExt = "FastDifferentiation"
-    DifferentiationInterfaceFiniteDiffExt = "FiniteDiff"
-    DifferentiationInterfaceFiniteDifferencesExt = "FiniteDifferences"
-    DifferentiationInterfaceForwardDiffExt = "ForwardDiff"
-    DifferentiationInterfacePolyesterForwardDiffExt = "PolyesterForwardDiff"
-    DifferentiationInterfaceReverseDiffExt = "ReverseDiff"
-    DifferentiationInterfaceSymbolicsExt = "Symbolics"
-    DifferentiationInterfaceTapirExt = "Tapir"
-    DifferentiationInterfaceTrackerExt = "Tracker"
-    DifferentiationInterfaceZygoteExt = ["Zygote", "ForwardDiff"]
-
-    [deps.DifferentiationInterface.weakdeps]
-    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-    Diffractor = "9f5e2b26-1114-432f-b630-d3fe2085c51c"
-    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
-    FastDifferentiation = "eb9bf01b-bf85-4b60-bf87-ee5de06c00be"
-    FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
-    FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
-    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-    PolyesterForwardDiff = "98d1487c-24ca-40b6-b7ab-df2af84e126b"
-    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
-    Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-    Tapir = "07d77754-e150-4737-8c94-cd238a1fb45b"
-    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-    Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
-
 [[deps.Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -372,22 +289,6 @@ version = "0.3.2"
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
-[[deps.FillArrays]]
-deps = ["LinearAlgebra"]
-git-tree-sha1 = "0653c0a2396a6da5bc4766c43041ef5fd3efbe57"
-uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.11.0"
-
-    [deps.FillArrays.extensions]
-    FillArraysPDMatsExt = "PDMats"
-    FillArraysSparseArraysExt = "SparseArrays"
-    FillArraysStatisticsExt = "Statistics"
-
-    [deps.FillArrays.weakdeps]
-    PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
-    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-    Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-
 [[deps.FixedPointNumbers]]
 deps = ["Statistics"]
 git-tree-sha1 = "05882d6995ae5c12bb5f36dd2ed3f61c98cbb172"
@@ -403,11 +304,6 @@ weakdeps = ["StaticArrays"]
 
     [deps.ForwardDiff.extensions]
     ForwardDiffStaticArraysExt = "StaticArrays"
-
-[[deps.FunctionWrappers]]
-git-tree-sha1 = "d62485945ce5ae9c0c48f124a84998d755bae00e"
-uuid = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
-version = "1.1.3"
 
 [[deps.Future]]
 deps = ["Random"]
@@ -430,18 +326,6 @@ deps = ["ExprTools", "InteractiveUtils", "LLVM", "Libdl", "Logging", "Preference
 git-tree-sha1 = "ab29216184312f99ff957b32cd63c2fe9c928b91"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 version = "0.26.7"
-
-[[deps.HSL]]
-deps = ["HSL_jll", "Libdl", "LinearAlgebra", "OpenBLAS32_jll", "SparseArrays"]
-git-tree-sha1 = "c5b95ac0b3bb0fc856b587b946fd2845e7fab8dd"
-uuid = "34c5aeac-e683-54a6-a0e9-6e0fdc586c50"
-version = "0.4.3"
-
-[[deps.HSL_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "6a7d6bbdbd0029ab369240414a1faff417ad80ef"
-uuid = "017b0a0e-03f4-516a-9b91-836bbd1904dd"
-version = "3.0.0+0"
 
 [[deps.Hwloc_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -517,11 +401,29 @@ git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.4"
 
+[[deps.JuMP]]
+deps = ["LinearAlgebra", "MacroTools", "MathOptInterface", "MutableArithmetics", "OrderedCollections", "PrecompileTools", "Printf", "SparseArrays"]
+git-tree-sha1 = "7e10a0d8b534f2d8e9f712b33488584254624fb1"
+uuid = "4076af6c-e467-56ae-b986-b466b2749572"
+version = "1.22.2"
+
+    [deps.JuMP.extensions]
+    JuMPDimensionalDataExt = "DimensionalData"
+
+    [deps.JuMP.weakdeps]
+    DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
+
 [[deps.JuliaNVTXCallbacks_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "af433a10f3942e882d3c671aacb203e006a5808f"
 uuid = "9c1d0b0a-7046-5b2e-a33f-ea22f176ac7e"
 version = "0.2.1+0"
+
+[[deps.KLU]]
+deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse_jll"]
+git-tree-sha1 = "884c2968c2e8e7e6bf5956af88cb46aa745c854b"
+uuid = "ef3ab10e-7fda-4108-b977-705223b18434"
+version = "0.4.1"
 
 [[deps.KernelAbstractions]]
 deps = ["Adapt", "Atomix", "InteractiveUtils", "LinearAlgebra", "MacroTools", "PrecompileTools", "Requires", "SparseArrays", "StaticArrays", "UUIDs", "UnsafeAtomics", "UnsafeAtomicsLLVM"]
@@ -639,11 +541,6 @@ git-tree-sha1 = "1fd0a97409e418b78c53fac671cf4622efdf0f21"
 uuid = "d00139f3-1899-568f-a2f0-47f597d42d70"
 version = "5.1.2+0"
 
-[[deps.MLStyle]]
-git-tree-sha1 = "bc38dff0548128765760c79eb7388a4b37fae2c8"
-uuid = "d8e11817-5142-5d16-987a-aa16d5891078"
-version = "0.4.17"
-
 [[deps.MUMPS_seq_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "METIS_jll", "libblastrampoline_jll"]
 git-tree-sha1 = "85047ac569761e3387717480a38a61d2a67df45c"
@@ -666,6 +563,18 @@ weakdeps = ["MathOptInterface"]
     [deps.MadNLP.extensions]
     MadNLPMOI = "MathOptInterface"
 
+[[deps.MadNLPGPU]]
+deps = ["AMD", "CUDA", "CUDSS", "CUSOLVERRF", "KernelAbstractions", "LinearAlgebra", "MadNLP", "MadNLPTests", "Metis", "SparseArrays"]
+git-tree-sha1 = "542846a6ecbaa6cbd7f3dbc6f86301b82b934a78"
+uuid = "d72a61cc-809d-412f-99be-fd81f4b8a598"
+version = "0.7.3"
+
+[[deps.MadNLPTests]]
+deps = ["JuMP", "LinearAlgebra", "MadNLP", "NLPModels", "NLPModelsJuMP", "Random", "SparseArrays", "Test"]
+git-tree-sha1 = "06f46773a08a3b88779a76dd1eb08a5d829dc084"
+uuid = "b52a2a03-04ab-4a5f-9698-6a2deff93217"
+version = "0.5.1"
+
 [[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
@@ -680,6 +589,22 @@ version = "1.31.1"
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 version = "2.28.2+1"
+
+[[deps.Metis]]
+deps = ["CEnum", "LinearAlgebra", "METIS_jll", "SparseArrays"]
+git-tree-sha1 = "5582d3b0d794280c9b818ba56ce2b35b108aca41"
+uuid = "2679e427-3c69-5b7f-982b-ece356f1e94b"
+version = "1.4.1"
+
+    [deps.Metis.extensions]
+    MetisGraphs = "Graphs"
+    MetisLightGraphs = "LightGraphs"
+    MetisSimpleWeightedGraphs = ["SimpleWeightedGraphs", "Graphs"]
+
+    [deps.Metis.weakdeps]
+    Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+    LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
+    SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"
 
 [[deps.Missings]]
 deps = ["DataAPI"]
@@ -702,15 +627,21 @@ version = "1.4.6"
 
 [[deps.NLPModels]]
 deps = ["FastClosures", "LinearAlgebra", "LinearOperators", "Printf", "SparseArrays"]
-git-tree-sha1 = "bf40a3b387d6238d0c353daed22289991ce95e77"
+git-tree-sha1 = "51b458add76a938917772ee661ffb9d59b4c7e5d"
 uuid = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
-version = "0.21.3"
+version = "0.20.0"
 
 [[deps.NLPModelsIpopt]]
 deps = ["Ipopt", "NLPModels", "SolverCore"]
 git-tree-sha1 = "b188ef0886fecd76827cacf9044ae1b3214185ee"
 uuid = "f4238b75-b362-5c4c-b852-0801c9a21d71"
 version = "0.10.2"
+
+[[deps.NLPModelsJuMP]]
+deps = ["JuMP", "LinearAlgebra", "MathOptInterface", "NLPModels", "Printf", "SolverCore", "SparseArrays"]
+git-tree-sha1 = "5186da6e38d5dbf2b4b4691e52197d65cca362a1"
+uuid = "792afdf1-32c1-5681-94e0-d7bf7a5df49e"
+version = "0.12.7"
 
 [[deps.NVTX]]
 deps = ["Colors", "JuliaNVTXCallbacks_jll", "Libdl", "NVTX_jll"]
@@ -765,28 +696,10 @@ git-tree-sha1 = "13652491f6856acfd2db29360e1bbcd4565d04f1"
 uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 version = "0.5.5+0"
 
-[[deps.OptimalControl]]
-deps = ["CTBase", "CTDirect", "CTFlows", "CommonSolve", "DocStringExtensions"]
-git-tree-sha1 = "dc219ecfc5bc405cd05b4dd0b06755589bec33d0"
-uuid = "5f98b655-cc9a-415a-b60e-744165666948"
-version = "0.10.0"
-
 [[deps.OrderedCollections]]
 git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.6.3"
-
-[[deps.PackageExtensionCompat]]
-git-tree-sha1 = "fb28e33b8a95c4cee25ce296c817d89cc2e53518"
-uuid = "65ce6f38-6b18-4e1d-a461-8949797d7930"
-version = "1.0.2"
-weakdeps = ["Requires", "TOML"]
-
-[[deps.Parameters]]
-deps = ["OrderedCollections", "UnPack"]
-git-tree-sha1 = "34c0e9ad262e5f7fc75b10a9952ca7692cfc5fbe"
-uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
-version = "0.12.3"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
@@ -866,23 +779,11 @@ git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 version = "1.2.2"
 
-[[deps.ReplMaker]]
-deps = ["REPL", "Unicode"]
-git-tree-sha1 = "f8bb680b97ee232c4c6591e213adc9c1e4ba0349"
-uuid = "b873ce64-0db9-51f5-a568-4457d8e49576"
-version = "0.2.7"
-
 [[deps.Requires]]
 deps = ["UUIDs"]
 git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
 version = "1.3.0"
-
-[[deps.ReverseDiff]]
-deps = ["ChainRulesCore", "DiffResults", "DiffRules", "ForwardDiff", "FunctionWrappers", "LinearAlgebra", "LogExpFunctions", "MacroTools", "NaNMath", "Random", "SpecialFunctions", "StaticArrays", "Statistics"]
-git-tree-sha1 = "cc6cd622481ea366bb9067859446a8b01d92b468"
-uuid = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
-version = "1.15.3"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -932,26 +833,6 @@ version = "1.2.1"
 deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 version = "1.10.0"
-
-[[deps.SparseConnectivityTracer]]
-deps = ["ADTypes", "Compat", "DocStringExtensions", "FillArrays", "LinearAlgebra", "Random", "Requires", "SparseArrays"]
-git-tree-sha1 = "50f8dcef2355909de25639cf936008d6e85ec2ae"
-uuid = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
-version = "0.6.0"
-
-    [deps.SparseConnectivityTracer.extensions]
-    SparseConnectivityTracerNNlibExt = "NNlib"
-    SparseConnectivityTracerSpecialFunctionsExt = "SpecialFunctions"
-
-    [deps.SparseConnectivityTracer.weakdeps]
-    NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
-    SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
-
-[[deps.SparseMatrixColorings]]
-deps = ["ADTypes", "Compat", "DocStringExtensions", "LinearAlgebra", "Random", "SparseArrays"]
-git-tree-sha1 = "ad048e784b816e4de5553a13f1daf148412f3dbd"
-uuid = "0a514795-09f3-496d-8182-132a7b665d35"
-version = "0.3.6"
 
 [[deps.SpecialFunctions]]
 deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
@@ -1043,11 +924,6 @@ weakdeps = ["Random", "Test"]
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
-
-[[deps.UnPack]]
-git-tree-sha1 = "387c1f73762231e86e0c9c5443ce3b4a0a9a0c2b"
-uuid = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
-version = "1.0.2"
 
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/exa2/goddard-exa2.jl
+++ b/exa2/goddard-exa2.jl
@@ -53,7 +53,7 @@ xs = xs.(t); xs = stack(xs[:])
 us = us.(t); us = stack(us[:])
 
 print_level = MadNLP.WARN
-tol = 1e-8
+tol = 1e-5
  
 function docp_exa(N=100; backend=nothing, tfs=0.1, xs=0.1, us=0.1)
 
@@ -80,6 +80,43 @@ function docp_exa(N=100; backend=nothing, tfs=0.1, xs=0.1, us=0.1)
     ExaModels.constraint(c, rk2(x[1, j], x[1, j+1], dr(x[1, j], x[2, j], x[3, j], u[1, j]), dr(x[1, j+1], x[2, j+1], x[3, j+1], u[1, j+1]), dt) for j ∈ 1:N) # To be optimised using additional vars
     ExaModels.constraint(c, rk2(x[2, j], x[2, j+1], dv(x[1, j], x[2, j], x[3, j], u[1, j]), dv(x[1, j+1], x[2, j+1], x[3, j+1], u[1, j+1]), dt) for j ∈ 1:N)
     ExaModels.constraint(c, rk2(x[3, j], x[3, j+1], dm(x[1, j], x[2, j], x[3, j], u[1, j]), dm(x[1, j+1], x[2, j+1], x[3, j+1], u[1, j+1]), dt) for j ∈ 1:N)
+
+    ExaModels.objective(c, -x[1, N+1])
+
+    return ExaModels.ExaModel(c)
+
+end
+
+function docp_exa_aux(N=100; backend=nothing, tfs=0.1, xs=0.1, us=0.1)
+
+    c = ExaModels.ExaCore(; backend=backend)
+
+    tf = ExaModels.variable(c, 1; start=tfs)
+    x = ExaModels.variable(c, n, 1:N+1; start=xs)
+    u = ExaModels.variable(c, m, 1:N+1; start=us)
+    s = ExaModels.variable(c, n, 1:N+1)
+
+    dt = tf[1] / N
+    ExaModels.constraint(c, tf[1]; lcon=0, ucon=Inf)
+    __it1 = [(i, [r0, v0, m0][i]) for i ∈ 1:n] 
+    ExaModels.constraint(c, x[i, 1] - __v for (i, __v) ∈ __it1)
+    ExaModels.constraint(c, x[3, N+1] - mf)
+    ExaModels.constraint(c, u[1, j] for j ∈ 1:N+1; lcon=0, ucon=1)
+    ExaModels.constraint(c, x[1, j] for j ∈ 1:N+1; lcon=r0, ucon=Inf)
+    ExaModels.constraint(c, x[2, j] for j ∈ 1:N+1; lcon=0, ucon=vmax)
+
+    dr(r, v, m, u) = v
+    dv(r, v, m, u) = -Cd * v^2 * exp(-β * (r - 1)) / m - 1 / r^2 + u * Tmax / m
+    dm(r, v, m, u) = -b * Tmax * u
+    rk2(x1, x2, rhs1, rhs2, dt) = x2 - x1 - dt / 2 * (rhs1 + rhs2)
+    
+    ExaModels.constraint(c, s[1, j] - dr(x[1, j], x[2, j], x[3, j], u[1, j]) for j ∈ 1:N+1)
+    ExaModels.constraint(c, s[2, j] - dv(x[1, j], x[2, j], x[3, j], u[1, j]) for j ∈ 1:N+1)
+    ExaModels.constraint(c, s[3, j] - dm(x[1, j], x[2, j], x[3, j], u[1, j]) for j ∈ 1:N+1)
+
+    ExaModels.constraint(c, rk2(x[1, j], x[1, j+1], s[1, j], s[1, j+1], dt) for j ∈ 1:N)
+    ExaModels.constraint(c, rk2(x[2, j], x[2, j+1], s[2, j], s[2, j+1], dt) for j ∈ 1:N)
+    ExaModels.constraint(c, rk2(x[3, j], x[3, j+1], s[3, j], s[3, j+1], dt) for j ∈ 1:N)
 
     ExaModels.objective(c, -x[1, N+1])
 


### PR DESCRIPTION
@0Yassine0 @amontoison new tests
- adding auxiliary variables to optimise computations
- lowering tolerances (going `1e-8` probably not so relevant on single precision GPU)

NB . @pierremartinon adding aux vars does not help much, compare `docp_exa` and `docp_exa_aux` in
https://github.com/jbcaillau/COTS.jl/blob/main/exa2/goddard-exa2.jl

## Naive RK2 (doc_exa)

### tol = 1e8

N = 100
exa0:  311.847 ms (25632 allocations: 240.12 MiB) # 90 iterations
exa1:  343.495 ms (50469 allocations: 242.28 MiB) # 90 iterations
exa2:  129.811 ms (313799 allocations: 8.74 MiB) # 20 iterations

N = 500
exa0:  734.530 ms (10977 allocations: 1.92 GiB) # 38 iterations
exa1:  733.023 ms (21471 allocations: 1.92 GiB) # 38 iterations
exa2:  628.971 ms (1183995 allocations: 32.42 MiB) # 67 iterations

N = 1000
exa0:  1.748 s (14564 allocations: 9.66 GiB) # 50 iterations
exa1:  1.602 s (28779 allocations: 9.66 GiB) # 50 iterations
exa2:  648.181 ms (1238880 allocations: 34.74 MiB) # 73 iterations

N = 5000
exa0:  6.547 s (9913 allocations: 64.37 GiB)  # 31 iterations
exa1:  6.637 s (41064 allocations: 64.37 GiB) # 31 iterations
exa2:  686.667 ms (658404 allocations: 22.20 MiB) # 34 iterations

### tol = 1e5

N = 100
exa0:  258.268 ms (22117 allocations: 209.36 MiB) # 79 iterations
exa1:  267.926 ms (43639 allocations: 211.22 MiB) # 79 iterations
exa2:  106.752 ms (251494 allocations: 7.26 MiB) # 18 iterations

N = 500
exa0:  468.069 ms (9332 allocations: 1.62 GiB) # 32 iterations
exa1:  477.723 ms (18283 allocations: 1.62 GiB) # 32 iterations
exa2:  179.100 ms (383549 allocations: 11.23 MiB) # 23 iterations

N = 1000
exa0:  1.316 s (13438 allocations: 8.91 GiB) # 46 iterations
exa1:  1.327 s (26576 allocations: 8.91 GiB) # 46 iterations
exa2:  1.253 s (2397445 allocations: 68.19 MiB) # 162 iterations

N = 5000
exa0:  5.100 s (7886 allocations: 50.31 GiB) # 27 iterations
exa1:  5.073 s (16848 allocations: 50.31 GiB) # 27 iterations
exa2:  631.891 ms (468724 allocations: 17.28 MiB) 24 # iterations

## With aux vars for RK2 (doc_exa_aux)

### tol = 1e8

N = 100
exa0:  112.978 ms (8493 allocations: 101.80 MiB) # 29 iterations
exa1:  114.552 ms (19071 allocations: 102.48 MiB # 29 iterations
exa2:  309.617 ms (812584 allocations: 20.07 MiB) # 90 iterations

N = 500
exa0:  670.554 ms (10340 allocations: 2.17 GiB) # 35 iterations
exa1:  683.194 ms (22910 allocations: 2.17 GiB) # 35 iterations
exa2:  991.213 ms (2161694 allocations: 52.10 MiB) # 72 iterations

N = 1000
exa0:  1.797 s (13588 allocations: 11.27 GiB) # 45 iterations
exa1:  1.809 s (30518 allocations: 11.27 GiB# 45 iterations
exa2:  1.528 s (2576710 allocations: 64.74 MiB# 131 iterations

N = 5000
exa0:  6.063 s (7826 allocations: 52.39 GiB) # 25 iterations
exa1:  6.116 s (17580 allocations: 52.39 GiB) # 25 iterations
exa2:  39.967 s (34875505 allocations: 848.54 MiB) # 197 iterations

### tol = 1e5

N = 100
exa0:  86.870 ms (7291 allocations: 80.83 MiB) # 25 iterations
exa1:  88.571 ms (16541 allocations: 81.43 MiB) # 25 iterations
exa2:  163.278 ms (384418 allocations: 10.33 MiB) # 23 iterations

N = 500
exa0:  524.903 ms (7891 allocations: 1.67 GiB) # 26 iterations
exa1:  527.392 ms (17473 allocations: 1.67 GiB) # 26 iterations
exa2:  242.957 ms (430171 allocations: 11.96 MiB) # 23 iterations

N = 1000
exa0:  1.617 s (12088 allocations: 10.00 GiB) # 40 iterations
exa1:  1.628 s (27092 allocations: 10.00 GiB) # 40 iterations
exa2:  324.310 ms (467385 allocations: 13.26 MiB) # 25 iterations

N = 5000
exa0:  5.220 s (6145 allocations: 40.32 GiB) # 19 iterations
exa1:  5.222 s (13799 allocations: 40.32 GiB) # 19 iterations
exa2:  809.408 ms (485910 allocations: 16.61 MiB) # 26 iterations